### PR TITLE
Add GRE protocol to iptables

### DIFF
--- a/ubuntu
+++ b/ubuntu
@@ -42,6 +42,7 @@ sysctl -p
 
 # Allow PPTP traffic on iptables
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+iptables -A ufw-before-input -p gre -j ACCEPT
 
 # Save iptable
 iptables-save


### PR DESCRIPTION
If GRE protocol is not allowed authentication won't happen at all.

This should fix the installation for a lot of users.